### PR TITLE
[MRG]Set up pytest to skip slow tests by default

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,17 @@
+"""Configuration for unit test suite, allows you to automatically
+skip tests marked as slow unless you provide the --runslow option
+on the commandline when invoking pytest
+"""
+
+import pytest
+
+def pytest_addoption(parser):
+    parser.addoption("--runslow", action="store_true", help="run slow tests")
+
+def pytest_runtest_setup(item):
+    """
+    Skip tests if they are marked as slow, unless the
+    test run is explicitly specified to run the slow tests
+    """
+    if 'slow' in item.keywords and not item.config.getoption("--runslow"):
+        pytest.skip("need --runslow option to run")

--- a/persephone/tests/test_tutorial.py
+++ b/persephone/tests/test_tutorial.py
@@ -1,11 +1,13 @@
 import os
 from os.path import join
+import pytest
 
 from persephone import corpus
 from persephone import run
 
 NA_EXAMPLE_LINK = "https://cloudstor.aarnet.edu.au/plus/s/YJXTLHkYvpG85kX/download"
 
+@pytest.mark.slow
 def test_ready_train():
     """ Pull the corpus from the link in the README. """
 

--- a/tox.ini
+++ b/tox.ini
@@ -5,4 +5,4 @@ deps=
     pytest
     pylint
 commands=
-    pytest -s
+    pytest -s {posargs}


### PR DESCRIPTION
These changes exist so you can mark slow tests with the decorator `@pytest.mark.slow` to exclude them from the default unit test runs. Supply `--runslow` via pytest command line invocation to run slow tests.

Note that via tox this will need to be `-- --runslow`

closes #70